### PR TITLE
Fix allow Maven release builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@ THE SOFTWARE.
     </dependency>
   </dependencies>
 
+  <scm>
+    <connection>scm:git:ssh://github.com/jenkinsci/mber-plugin.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/jenkinsci/mber-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/mber-plugin</url>
+  </scm>
+
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ THE SOFTWARE.
   <version>1.0.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Mber Plugin</name>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Mber+Plugins</url>
+  <url>https://wiki.jenkins-ci.org/display/JENKINS/Mber+Plugin</url>
 
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,6 @@ THE SOFTWARE.
     <version>1.509.2</version>
   </parent>
 
-  <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>mber</artifactId>
   <version>1.0.0</version>
   <packaging>hpi</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@ THE SOFTWARE.
   </parent>
 
   <artifactId>mber</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Mber Plugin</name>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Mber+Plugins</url>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,13 @@ THE SOFTWARE.
     <url>https://github.com/jenkinsci/mber-plugin</url>
   </scm>
 
+  <distributionManagement>
+    <repository>
+      <id>maven.jenkins-ci.org</id>
+      <url>http://maven.jenkins-ci.org/content/repositories/releases/</url>
+    </repository>
+  </distributionManagement>
+
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,13 @@ THE SOFTWARE.
   <name>Mber Plugin</name>
   <url>https://member.firepub.net</url>
 
+  <licenses>
+    <license>
+      <name>MIT license</name>
+      <url>http://opensource.org/licenses/mit-license.html</url>
+    </license>
+ </licenses>
+
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ THE SOFTWARE.
   <version>1.0.0</version>
   <packaging>hpi</packaging>
   <name>Mber Plugin</name>
-  <url>https://member.firepub.net</url>
+  <url>https://wiki.jenkins-ci.org/display/JENKINS/Mber+Plugins</url>
 
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,15 @@ THE SOFTWARE.
       <name>MIT license</name>
       <url>http://opensource.org/licenses/mit-license.html</url>
     </license>
- </licenses>
+  </licenses>
+
+  <developers>
+    <developer>
+      <id>onefrankguy</id>
+      <name>Frank Mitchell</name>
+      <email>fmitchell@mber.com</email>
+    </developer>
+  </developers>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
This tweaks the root POM so "mvn release" commands work. See the official documentation around plugins for details.

https://wiki.jenkins-ci.org/display/JENKINS/Hosting+Plugins
